### PR TITLE
feature/provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ const styles = StyleSheet.create({
 | **priorityMarker**       | _ReactNode_  | null                                                  | Marker which will be outside of clusters |
 | **renderClusterMarker**  | ():ReactNode | () => { return \<CustomClusterMarker /> }             | Returns cluster marker component         |
 | **clusterMarkerProps**   | _object_     | undefined                                             | Additional ClusterMarker props           |
+| **provider**                | _'google'_ or _null_  | 'google'                                    | Map provider. If null will use the platform default one (Google Maps for Android and MapKit for iOS)                     |
 | **style**                | _StyleProp_  | absoluteFillObject                                    | Styling for MapView                      |
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-cluster-map",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "React Native MapView clustering component for iOS + Android",
   "keywords": [
     "android",

--- a/src/cluster-map.tsx
+++ b/src/cluster-map.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StyleSheet } from 'react-native';
-import GoogleMapView, { PROVIDER_GOOGLE, Region } from 'react-native-maps';
+import MapView, { Region, PROVIDER_GOOGLE, PROVIDER_DEFAULT } from 'react-native-maps';
 import isEqual from 'lodash.isequal';
 
 import { ClusterMarker } from './cluster-marker';
@@ -22,7 +22,7 @@ export class ClusterMap extends React.PureComponent<
   public static defaultProps: Partial<IClusterMapProps> = {
     isClusterExpandClick: true,
   };
-  public mapRef: GoogleMapView;
+  public mapRef: MapView;
   public state: IClusterMapState = {
     markers: [],
     isMapLoaded: false,
@@ -30,21 +30,21 @@ export class ClusterMap extends React.PureComponent<
   };
 
   public render() {
-    const { style, region, priorityMarker } = this.props;
+    const { style, region, priorityMarker, provider } = this.props;
 
     return (
-      <GoogleMapView
+      <MapView
         {...utils.serializeProps(this.props)}
         ref={(ref) => (this.mapRef = ref)}
         style={style || styles.map}
         onMapReady={this.onMapReady}
         initialRegion={region}
         onRegionChangeComplete={this.onRegionChangeComplete}
-        provider={PROVIDER_GOOGLE}
+        provider={provider === PROVIDER_DEFAULT ? null : PROVIDER_GOOGLE}
       >
         {this.state.isMapLoaded && this.renderMarkers()}
         {priorityMarker ? priorityMarker : null}
-      </GoogleMapView>
+      </MapView>
     );
   }
 

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -1,6 +1,6 @@
 import { ReactNode, ReactElement } from 'react';
 import { StyleProp, ViewStyle } from 'react-native';
-import { LatLng, MapViewProps, Region, Marker } from 'react-native-maps';
+import { LatLng, MapViewProps, Region, PROVIDER_GOOGLE, PROVIDER_DEFAULT } from 'react-native-maps';
 import SuperCluster from 'supercluster';
 
 export interface IClusterMapProps extends MapViewProps {
@@ -18,6 +18,7 @@ export interface IClusterMapProps extends MapViewProps {
       | Array<SuperCluster.PointFeature<any>>) => void;
   onRegionChangeComplete: (region: Region) => void;
   clusterMarkerProps?: object;
+  provider: typeof PROVIDER_DEFAULT | typeof PROVIDER_GOOGLE;
 }
 
 export interface ICoords {


### PR DESCRIPTION
Hi, I added the prop 'provider'. If not specified it now uses the default ones (GoogleMaps on Android and MapKit on iOS), and can be forced on both if provider = 'google'. 
I was trying to use the library with MapKit but it kept trying to use GoogleMaps on iOS too, causing my app to crash. This fixes it.