### PR TITLE
feature/add support for non-clustered children

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,13 @@ const styles = StyleSheet.create({
 
 > Also contains react-native-maps [\<MapView /> Props](https://github.com/react-native-community/react-native-maps/blob/master/docs/mapview.md#props)
 
+
+## Children Props
+
+| Props                    | Type         | Default                                               | Note                                     |
+| ------------------------ | ------------ | ----------------------------------------------------- | ---------------------------------------- |
+| **neverCluster**  | _boolean_    | false | Tag a child of the Map to not be clustered. This prop is **_required_** for non-marker children of the map, such as geo-fences and overlays, or any child that does not have a `coordinates` prop. |
+
 ## Events
 
 | Event Name         | Returns                                                          | Notes                                                                     |

--- a/src/cluster-map.tsx
+++ b/src/cluster-map.tsx
@@ -95,7 +95,7 @@ export class ClusterMap extends React.PureComponent<
     const { superClusterOptions, region, children } = this.props;
     clusterService.createClusters(
       superClusterOptions,
-      children.filter((child: ReactElement) => !child.props.neverCluster)
+      children
     );
     this.generateMarkers(region);
   };
@@ -143,7 +143,16 @@ export class ClusterMap extends React.PureComponent<
 
   private renderUnclusteredChildren = () => {
     const { children } = this.props;
-    return children.filter((child: ReactElement) => child.props.neverCluster);
+
+    if (Array.isArray(children)) {
+      return children.filter((child: ReactElement) => child.props.neverCluster);
+    }
+
+    if (children.props && children.props.neverCluster) {
+      return [children];
+    }
+
+    return [];
   };
 
   private renderChildren = () => {

--- a/src/cluster-map.tsx
+++ b/src/cluster-map.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 import { StyleSheet } from 'react-native';
 import MapView, { Region, PROVIDER_GOOGLE, PROVIDER_DEFAULT } from 'react-native-maps';
 import isEqual from 'lodash.isequal';
@@ -42,7 +42,7 @@ export class ClusterMap extends React.PureComponent<
         onRegionChangeComplete={this.onRegionChangeComplete}
         provider={provider === PROVIDER_DEFAULT ? null : PROVIDER_GOOGLE}
       >
-        {this.state.isMapLoaded && this.renderMarkers()}
+        {this.state.isMapLoaded && this.renderChildren()}
         {priorityMarker ? priorityMarker : null}
       </MapView>
     );
@@ -93,7 +93,10 @@ export class ClusterMap extends React.PureComponent<
 
   private clusterize = () => {
     const { superClusterOptions, region, children } = this.props;
-    clusterService.createClusters(superClusterOptions, children);
+    clusterService.createClusters(
+      superClusterOptions,
+      children.filter((child: ReactElement) => !child.props.neverCluster)
+    );
     this.generateMarkers(region);
   };
 
@@ -136,6 +139,15 @@ export class ClusterMap extends React.PureComponent<
         </ClusterMarker>
       );
     });
+  };
+
+  private renderUnclusteredChildren = () => {
+    const { children } = this.props;
+    return children.filter((child: ReactElement) => child.props.neverCluster);
+  };
+
+  private renderChildren = () => {
+    return [...this.renderMarkers(), ...this.renderUnclusteredChildren()];
   };
 
   private onMapReady = () => {

--- a/src/cluster-service.ts
+++ b/src/cluster-service.ts
@@ -122,7 +122,7 @@ export class ClusterService {
       return [children];
     }
 
-    return children;
+    return children.filter((child: ReactElement) => !child.props.neverCluster);
   };
   // TODO: Add unit test
   private getClusterMarkers = (


### PR DESCRIPTION
Fixes #33 
Added a check for a `neverCluster` prop on children of the map to exclude them from the clustering process. This allows use of child components such as GeoFences and Overlays, with the Cluster Map.