### PR TITLE
bugfix/support-not-flat-children

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { StyleSheet, View, Text, TouchableOpacity } from 'react-native';
-import MapView, { PROVIDER_GOOGLE, Marker } from 'react-native-maps';
-import { ClusterMap } from '../src';
+import { PROVIDER_GOOGLE, Marker, Circle } from 'react-native-maps';
+import { ClusterMap } from 'react-native-cluster-map';
 
 const markers = [
   { latitude: 37.78825, longitude: -122.4324 },
@@ -16,8 +16,8 @@ const App = () => {
   const onAddMarkers = () => {
     setMarkers([
       ...markersState,
-      { latitude: 37.78825, longitude: -122.4647 },
-      { latitude: 37.78925, longitude: -122.4647 },
+      { latitude: 37.78825, longitude: -122.4247 },
+      { latitude: 37.79925, longitude: -122.4247 },
     ]);
   };
 
@@ -35,13 +35,34 @@ const App = () => {
           longitudeDelta: 0.0421,
         }}
       >
+        <Circle
+          center={{ latitude: 37.78832, longitude: -122.419 }}
+          radius={500}
+          strokeColor={'#F3DB2C'}
+          strokeWidth={10}
+          {...{ isOutsideCluster: true }}
+        />
+        <Circle
+          center={{ latitude: 37.78852, longitude: -122.444 }}
+          radius={700}
+          strokeColor={'#FF5733'}
+          strokeWidth={10}
+          {...{ isOutsideCluster: true }}
+        />
+        <Circle
+          center={{ latitude: 37.78872, longitude: -122.454 }}
+          radius={1000}
+          strokeColor={'#3E588A'}
+          strokeWidth={10}
+          {...{ isOutsideCluster: true }}
+        />
         {markersState.map((marker, id) => {
           return <Marker coordinate={marker} key={id} />;
         })}
       </ClusterMap>
 
       <TouchableOpacity onPress={onAddMarkers} style={styles.addMarkerButton}>
-        <Text>Set markers</Text>
+        <Text>Add markers</Text>
       </TouchableOpacity>
     </View>
   );

--- a/example/package.json
+++ b/example/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "react": "16.8.6",
     "react-native": "0.60.3",
-    "react-native-cluster-map": "^1.0.2",
+    "react-native-cluster-map": "^1.0.8",
     "react-native-maps": "^0.25.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-cluster-map",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "React Native MapView clustering component for iOS + Android",
   "keywords": [
     "android",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,11 +24,13 @@ export const formatChildren = (
 
   const childrenList = !Array.isArray(children) ? [children] : children;
 
-  return childrenList.filter((child: ReactElement) =>
-    isInCluster
-      ? child.props.isOutsideCluster !== true
-      : child.props.isOutsideCluster
-  );
+  return childrenList
+    .flat(1)
+    .filter((child: ReactElement) =>
+      isInCluster && child.props
+        ? child.props.isOutsideCluster !== true
+        : child.props.isOutsideCluster
+    );
 };
 
 export const serializeProps = (userProps: IClusterMapProps) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "target": "es6",
     "noEmit": true,
     "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "lib": ["es2019"]
   },
   "exclude": ["node_modules", "rollup.config.js", "example", "src/spec"]
 }


### PR DESCRIPTION
Support for non-only array children. Such as [Circle, markers.map, Polygon]

Resolve #40 