### PR TITLE
Update typings.ts

### DIFF
--- a/src/typings.ts
+++ b/src/typings.ts
@@ -8,7 +8,7 @@ export interface IClusterMapProps extends MapViewProps {
   superClusterOptions?: object;
   priorityMarker?: React.ReactElement;
   region: Region;
-  children: ReactElement[] | ReactElement;
+  children: ReactElement[] | ReactElement | Element[] | Element;
   style: StyleProp<ViewStyle>;
   onZoomChange?: (zoom: number) => void;
   renderClusterMarker: (renderClusterMarkerOptions: { pointCount: number, clusterId: number }) => ReactNode;


### PR DESCRIPTION
Creating jsx elements programatically inside a <ClusterMap>, e.g. {list.map( ele=> (<Marker> <CustomComponent/></Marker>) ) }, resulted in 'Types of property 'children' are incompatible.'